### PR TITLE
fix: sql schema hardcoded in method query_get_table_metadata  #212

### DIFF
--- a/datachecks/core/datasource/sql_datasource.py
+++ b/datachecks/core/datasource/sql_datasource.py
@@ -79,7 +79,7 @@ class SQLDataSource(DataSource):
         Get the table metadata
         :return: query for table metadata
         """
-        return inspect(self.connection.engine).get_table_names(schema="public")
+        return inspect(self.connection.engine).get_table_names()
 
     def query_get_row_count(self, table: str, filters: str = None) -> int:
         """


### PR DESCRIPTION
### Fixes/Implements #

## Description

 Get table name from defined `schema`

## Type of change
 Remove `schema` param from `get_table_names` method, if schema is not passed it'll use default schema for the database.

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Locally Tested
- [ ] Needs Testing From Production